### PR TITLE
Add lilggamegenuis to the tilde user name substitution list

### DIFF
--- a/scripts/tilde_users.rb
+++ b/scripts/tilde_users.rb
@@ -56,6 +56,7 @@ class TildeUsers
       when 'staplebut'   ; 'staplebutter'
       when 'synergian'   ; 'synergiance'
       when 'Zeether'     ; 'zeether'
+      when 'Lil-G'       ; 'lilggamegenuis'
       else               ;  name
     end
   end


### PR DESCRIPTION
Tilde user lilggamegenuis goes by Lil-G on IRC. This adds them to the list.